### PR TITLE
Fixing issue where a 'double tap' would be required to interact with autoCompleteButton

### DIFF
--- a/HTAutocompleteTextField.m
+++ b/HTAutocompleteTextField.m
@@ -285,6 +285,10 @@ static NSObject<HTAutocompleteDataSource> *DefaultAutocompleteDataSource = nil;
         {
             self.autocompleteButton.alpha = 0;
         }
+        // Needed to ensure button really is brought to front
+        // and doesn't require user to 'double tap' to dismiss
+        // copy/paste popup first
+        [self bringSubviewToFront:self.autocompleteButton];
     };
     
     if (animated)


### PR DESCRIPTION
Ensuring that the autoCompleteButton subview is brought to front when updated to ensure that when tapped the button receives the event rather than the text field.
