### PR TITLE
Add delegate to allow for notifications when certain events happen

### DIFF
--- a/HTAutocompleteTextField.h
+++ b/HTAutocompleteTextField.h
@@ -20,6 +20,14 @@
 
 @end
 
+@protocol HTAutocompleteTextFieldDelegate <NSObject>
+
+@optional
+- (void)autoCompleteTextFieldDidAutoComplete:(HTAutocompleteTextField *)autoCompleteField;
+- (void)autocompleteTextField:(HTAutocompleteTextField *)autocompleteTextField didChangeAutocompleteText:(NSString *)autocompleteText;
+
+@end
+
 @interface HTAutocompleteTextField : UITextField
 
 /*
@@ -35,6 +43,7 @@
 @property (nonatomic, assign) BOOL ignoreCase;
 @property (nonatomic, assign) BOOL needsClearButtonSpace;
 @property (nonatomic, assign) BOOL showAutocompleteButton;
+@property (nonatomic, assign) id<HTAutocompleteTextFieldDelegate> autoCompleteTextFieldDelegate;
 
 /*
  * Configure text field appearance

--- a/HTAutocompleteTextField.m
+++ b/HTAutocompleteTextField.m
@@ -173,6 +173,10 @@ static NSObject<HTAutocompleteDataSource> *DefaultAutocompleteDataSource = nil;
     [self.autocompleteLabel setText:self.autocompleteString];
     [self.autocompleteLabel sizeToFit];
     [self.autocompleteLabel setFrame: [self autocompleteRectForBounds:self.bounds]];
+	
+	if ([self.autoCompleteTextFieldDelegate respondsToSelector:@selector(autocompleteTextField:didChangeAutocompleteText:)]) {
+		[self.autoCompleteTextFieldDelegate autocompleteTextField:self didChangeAutocompleteText:self.autocompleteString];
+	}
 }
 
 - (void)refreshAutocompleteText
@@ -217,6 +221,10 @@ static NSObject<HTAutocompleteDataSource> *DefaultAutocompleteDataSource = nil;
         
         self.autocompleteString = @"";
         [self updateAutocompleteLabel];
+		
+		if ([self.autoCompleteTextFieldDelegate respondsToSelector:@selector(autoCompleteTextFieldDidAutoComplete:)]) {
+			[self.autoCompleteTextFieldDelegate autoCompleteTextFieldDidAutoComplete:self];
+		}
     }
     return ![currentText isEqualToString:self.text];
 }


### PR DESCRIPTION
# What this does

This adds a delegate to allow an object to receive notifications about autocomplete events. The two events that I added delegate methods for are when the autocomplete field did commit the autocompletion, and when the autocomplete text was updated.
