### PR TITLE
Fix so that returning nil as the autocomplete string works when committing the autocomplete text.

### DIFF
--- a/HTTextFieldAutocompletionExample/HTAutocompleteTextField.m
+++ b/HTTextFieldAutocompletionExample/HTAutocompleteTextField.m
@@ -231,7 +231,7 @@ static NSObject<HTAutocompleteDataSource> *DefaultAutocompleteDataSource = nil;
 - (BOOL)commitAutocompleteText
 {
     NSString *currentText = self.text;
-    if ([self.autocompleteString isEqualToString:@""] == NO
+    if (self.autocompleteString.length > 0
         && self.autocompleteDisabled == NO)
     {
         self.text = [NSString stringWithFormat:@"%@%@", self.text, self.autocompleteString];


### PR DESCRIPTION
First of great autocomplete solution. Love it! I did run into some small things, hope to help improve this project with a PR. Let me know if I need to explain more/change anything to merge this in!

**The problem:**
When committing the autocomplete string while the datasource returned `nil` for the autocomplete string. The result is like `prefix(null)`.

**The fix:**
`[HTAutocompleteTextField refreshAutocompleteText]` already checks the length of the string instead of an `isEqualToString:` check. I've implemented this also in the [HTAutocompleteTextField commitAutocompleteText]` method. This solves the problem.
